### PR TITLE
Fix dark mode transitions on Chrome

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
-body * {
-  @apply transition-colors duration-300;
+:root {
+  --dark-mode-transition-duration: 150ms;
+}
+
+[class*="dark:bg-"],
+[class*="dark:border-"] {
+  transition-property: background-color, border-color;
+  transition-duration: var(--dark-mode-transition-duration);
+}
+
+[class*="dark:text-"] {
+  transition-property: color;
+  transition-duration: var(--dark-mode-transition-duration);
 }
 
 .lucide {


### PR DESCRIPTION
With transitions applied like this:

```css
a, span {
  transition-property: color;
  transition-duration: 1s;
}
```

...the color of transitioning elements will stagger if the HTML structure looks like this:

```html
<a className="text-red dark:text-black"><span>Bazinga</span></a>
```

The `a` element will begin its transition to black at `t=0`. The `span` inherits its color, but there seems to be a browser difference:

- On Firefox, the `span` inherits the new color at `t=0`
- On Chrome, the `span` inherits the new color at `t=transition-duration`

That causes a staggered effect (on Chrome) where the color transition of the `Bazinga` text begins with a delay.

To fix this, I've made the transition properties and the classes they target a little bit more surgical, to avoid cases where one element applies a transition of a property that it's inheriting from a parent. Basically, an element should only have a transition on a property for which it has its own value (i.e. not inherited).